### PR TITLE
Second batch of forcing linear into textures + better organization 

### DIFF
--- a/ULUS10391/textures.ini
+++ b/ULUS10391/textures.ini
@@ -5851,6 +5851,21 @@ Monster:
 0000000000000000a669bf78 = Monster/Large/095bc4e03941cabaa669bf78.png
 
 [filtering]
+
+UI:
+
+# /UI/2G(FUC)/EFX/ This stuff is used globally, even when you less expect it lol
+0000000000000000dde85034 = linear
+0000000000000000d5688155 = linear
+00000000000000005fc86808 = linear
+0000000000000000deb3e9a0 = linear
+000000000000000081c70889 = linear
+000000000000000004a927fd = linear
+000000000000000004f6c221 = linear
+000000000000000021acb84e = linear
+
+Village Facilities:
+
 # /stage/Village/Base/
 0000000000000000014ca8b4 = linear
 00000000000000007fdeee04 = linear
@@ -5866,6 +5881,7 @@ Monster:
 000000000000000026e8b80b = linear
 0000000000000000898da1cd = linear
 00000000000000008c8be196 = linear
+
 # /stage/Village/Kitchen/
 000000000000000034184b55 = linear
 0000000000000000e1a6cda1 = linear
@@ -5873,15 +5889,7 @@ Monster:
 0000000000000000214cf54c = linear
 00000000000000005d57fba9 = linear
 00000000000000008f100a00 = linear
-# /UI/2G(FUC)/EFX/ This stuff is used globally, even when you less expect it lol
-0000000000000000dde85034 = linear
-0000000000000000d5688155 = linear
-00000000000000005fc86808 = linear
-0000000000000000deb3e9a0 = linear
-000000000000000081c70889 = linear
-000000000000000004a927fd = linear
-000000000000000004f6c221 = linear
-000000000000000021acb84e = linear
+
 # /stage/Village/Farm/
 0000000000000000a7e97be4 = linear
 0000000000000000bf303216 = linear
@@ -5892,9 +5900,45 @@ Monster:
 000000000000000052f75431 = linear
 0000000000000000c2e72331 = linear
 000000000000000064137b4a = linear
+
 # /stage/Village/Guild-Hall/
 09731af0604023bc90e63866 = linear
 09732360c5e08f6ceb1670bc = linear
+
+Town:
+
+# /stage/Town/Base/
+0000000000000000ca0bd83f = linear
+0000000000000000cd5ca38b = linear
+
+# /stage/Town/Area1/ (dont ask me why this door texture fucks up the sky if its 
+# not set on linear or auto, i don't know. Amanda)
+0000000000000000427e4657 = linear
+
+# /stage/Town/Area1/
+00000000000000004b4e59f5 = linear
+
+# /stage/Town/Area2/
+00000000000000009e66e58f = linear
+
+# /stage/Town/Area3/
+0000000000000000d1dba1a4 = linear
+
+Monster:
+
+# Monsters SFX /Monster/Large/
+0000000000000000a1356d14 = linear
+0000000000000000a669bf78 = linear
+0000000000000000e6f4cb1e = linear
+0000000000000000f4f72e8b = linear
+0000000000000000a8bec88f = linear
+0000000000000000032a7e4b = linear
+000000000000000046bdc97f = linear
+0000000000000000544e8229 = linear 
+00000000000000002f00d8b7 = linear
+0000000000000000a8649360 = linear
+0000000000000000cf78651b = linear
+0000000000000000f3a5c89e = linear
 [hashranges]
 0x0419c200,256,256 = 160,160
 0x091bf4d0,512,512 = 480,272


### PR DESCRIPTION
This includes filtering for the town maps, making the water, smoke and skyboxes look great on nearest! Same goes for monster blast attacks.
The main thing on this one is fortress skyboxes are now fixed for people that play nearest >:3
Also, the filtering section has been better organized so we know what section are modified by it!
Before: 
![Screenshot_03022024_115611](https://github.com/Monkbreh/MHFU-Texture-Port/assets/89411895/fedd53be-d289-4af0-a55a-04e0c404c9bd)
After:
![Screenshot_03022024_115849](https://github.com/Monkbreh/MHFU-Texture-Port/assets/89411895/7266d8b2-1f5d-4dcb-b68b-2e11a9040bbe)

Before:
![Screenshot_03022024_105453](https://github.com/Monkbreh/MHFU-Texture-Port/assets/89411895/6885a7a7-39ba-4bf5-ad55-f24ab02ac1c7)
After:
![Screenshot_03022024_111811](https://github.com/Monkbreh/MHFU-Texture-Port/assets/89411895/bf28b3eb-e8ee-49f7-b238-474ce045f3e5)

